### PR TITLE
Update `[compat]` for Polynomials.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 
 [compat]
 LibAMVW_jll = "1"
-Polynomials = "0.7"
+Polynomials = "0.7, 0.8, 1.0"
 julia = "1.3"
 
 [extras]


### PR DESCRIPTION
`Polynomials.jl` has been updated to `v1.0.4`. And current `[compat]` is blocking updating it. Is there special consideration for it? I have run the tests on `v1.0.4`, it works, though.